### PR TITLE
Change to pruning conditions

### DIFF
--- a/src/board_representation/game_state.rs
+++ b/src/board_representation/game_state.rs
@@ -867,11 +867,11 @@ impl GameState {
     }
 
     #[inline(always)]
-    pub fn has_non_pawns(&self) -> bool {
-        (self.pieces[BISHOP][WHITE] | self.pieces[BISHOP][BLACK]) != 0u64
-            || (self.pieces[KNIGHT][WHITE] | self.pieces[KNIGHT][BLACK]) != 0u64
-            || (self.pieces[ROOK][WHITE] | self.pieces[ROOK][BLACK]) != 0u64
-            || (self.pieces[QUEEN][WHITE] | self.pieces[QUEEN][BLACK]) != 0u64
+    pub fn has_non_pawns(&self, side: usize) -> bool {
+        self.pieces[BISHOP][side] != 0u64
+            || self.pieces[KNIGHT][side] != 0u64
+            || self.pieces[ROOK][side] != 0u64
+            || self.pieces[QUEEN][side] != 0u64
     }
 }
 

--- a/src/board_representation/game_state.rs
+++ b/src/board_representation/game_state.rs
@@ -865,6 +865,14 @@ impl GameState {
     pub fn king_square(&self, side: usize) -> usize {
         self.pieces[KING][side].trailing_zeros() as usize
     }
+
+    #[inline(always)]
+    pub fn has_non_pawns(&self) -> bool {
+        (self.pieces[BISHOP][WHITE] | self.pieces[BISHOP][BLACK]) != 0u64
+            || (self.pieces[KNIGHT][WHITE] | self.pieces[KNIGHT][BLACK]) != 0u64
+            || (self.pieces[ROOK][WHITE] | self.pieces[ROOK][BLACK]) != 0u64
+            || (self.pieces[QUEEN][WHITE] | self.pieces[QUEEN][BLACK]) != 0u64
+    }
 }
 
 impl Clone for GameState {

--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -193,6 +193,7 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
             && is_quiet_move
             && current_max_score > MATED_IN_MAX
             && p.game_state.has_non_pawns(p.game_state.color_to_move)
+            && !in_check_slow(&next_state)
         {
             //Step 14.5. Futility Pruning. Skip quiet moves if futil_margin can't raise alpha
             if futil_margin <= p.alpha {

--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -98,7 +98,7 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
 
     //Step 9. Static Eval if needed
     let prunable = !is_pv_node && !incheck;
-    make_eval(&p, thread, &mut static_evaluation, prunable, incheck);
+    make_eval(&p, thread, &mut static_evaluation, prunable);
 
     //Step 10. Prunings
     if prunable {
@@ -134,7 +134,7 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
     };
 
     //Step 12. Futil Pruning and margin preparation
-    let futil_margin = prepare_futility_pruning(&p, incheck, static_evaluation);
+    let futil_margin = prepare_futility_pruning(&p, static_evaluation);
     //Step 13. Prepare staged movegen
     let hash_and_pv_move_counter =
         prepare_staged_movegen(&p, thread, has_generated_moves, &pv_table_move, &tt_move);
@@ -419,12 +419,11 @@ pub fn make_eval(
     thread: &mut Thread,
     static_evaluation: &mut Option<i16>,
     prunable: bool,
-    incheck: bool,
 ) {
     if static_evaluation.is_none()
         && (prunable
             && (p.depth_left <= STATIC_NULL_MOVE_DEPTH || p.depth_left >= NULL_MOVE_PRUNING_DEPTH)
-            || !incheck && p.depth_left <= FUTILITY_DEPTH)
+            || p.depth_left <= FUTILITY_DEPTH)
     {
         let eval_res = eval_game_state(
             p.game_state,
@@ -522,7 +521,6 @@ pub fn internal_iterative_deepening(
 #[inline(always)]
 pub fn prepare_futility_pruning(
     p: &CombinedSearchParameters,
-    incheck: bool,
     static_evaluation: Option<i16>,
 ) -> (i16) {
     let futil_pruning = p.depth_left <= FUTILITY_DEPTH && p.current_depth > 0;

--- a/src/search/alphabeta.rs
+++ b/src/search/alphabeta.rs
@@ -189,7 +189,11 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
         let is_quiet_move = !isc && !isp;
         let next_state = make_move(p.game_state, &mv);
 
-        if is_quiet_move && current_max_score > MATED_IN_MAX && p.game_state.has_non_pawns() {
+        if !root
+            && is_quiet_move
+            && current_max_score > MATED_IN_MAX
+            && p.game_state.has_non_pawns(p.game_state.color_to_move)
+        {
             //Step 14.5. Futility Pruning. Skip quiet moves if futil_margin can't raise alpha
             if futil_margin <= p.alpha {
                 thread.search_statistics.add_futil_pruning();
@@ -462,7 +466,7 @@ pub fn null_move_pruning(
     static_evaluation: Option<i16>,
 ) -> SearchInstruction {
     if p.depth_left >= NULL_MOVE_PRUNING_DEPTH
-        && p.game_state.has_non_pawns()
+        && p.game_state.has_non_pawns(p.game_state.color_to_move)
         && static_evaluation.expect("null move static") * p.color >= p.beta
     {
         let nextgs = make_nullmove(p.game_state);


### PR DESCRIPTION
Pruning conditions have vastly changed.Null Move Forward Pruning previously was not applied when phase was 0. This already applies when there are only few minor pieces left on the board. This was now changed, Null Move Pruning is not applied when the side to move only has pawns left.

Previously, Futility and History Pruning were not used when the side to move is in check. This is no longer the case.
The new pre conditions for Futility and History Pruning are:

- Not at root
- Move is quiet( non-capture non-promotion)
- Move does not give check
- current_score > WORST_SCORE
- Side to move has a piece other than pawns


ELO   | 25.54 +- 11.49 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2235 W: 790 L: 626 D: 819
http://192.168.178.35:8000/viewTest/16/

ELO   | 43.96 +- 14.67 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1160 W: 382 L: 236 D: 542
http://192.168.178.35:8000/viewTest/17/

Bench: 17605456