### PR TITLE
Tune search parameters, Fail Lows

### DIFF
--- a/src/board_representation/game_state.rs
+++ b/src/board_representation/game_state.rs
@@ -5,7 +5,6 @@ use crate::evaluation::phase::Phase;
 use crate::evaluation::EvaluationScore;
 use crate::move_generation::makemove::make_move;
 use crate::move_generation::movegen::{generate_moves, MoveList};
-use crate::search::quiescence::is_capture;
 use std::fmt::{Debug, Display, Formatter, Result};
 
 pub const PAWN: usize = 0;
@@ -134,6 +133,19 @@ impl Clone for GameMove {
 }
 
 impl GameMove {
+    #[inline(always)]
+    pub fn is_capture(&self) -> bool {
+        match self.move_type {
+            GameMoveType::Capture(_) => true,
+            GameMoveType::Promotion(_, s) => match s {
+                Some(_) => true,
+                _ => false,
+            },
+            GameMoveType::EnPassant => true,
+            _ => false,
+        }
+    }
+
     pub fn string_to_move(desc: &str) -> (usize, usize, Option<PieceType>) {
         let mut chars = desc.chars();
         let from_file = match chars.nth(0) {
@@ -220,7 +232,7 @@ impl GameMove {
             if rank_needed {
                 res_str.push_str(&format!("{}", self.from / 8 + 1))
             };
-            if is_capture(self) {
+            if self.is_capture() {
                 if self.piece_type == PieceType::Pawn && !file_needed {
                     res_str.push_str(file_to_string((self.from % 8) as usize));
                 }

--- a/src/evaluation/mod.rs
+++ b/src/evaluation/mod.rs
@@ -4,7 +4,7 @@ pub mod psqt_evaluation;
 
 use super::bitboards;
 use super::board_representation::game_state::{
-    GameState, PieceType, BISHOP, BLACK, KING, KNIGHT, PAWN, QUEEN, ROOK, WHITE,
+    GameState, BISHOP, BLACK, KING, KNIGHT, PAWN, QUEEN, ROOK, WHITE,
 };
 #[cfg(feature = "display-eval")]
 use super::logging::log;
@@ -1132,8 +1132,4 @@ pub fn piece_values(white: bool, g: &GameState, _eval: &mut EvaluationResult) ->
         log(&format!("Sum: {}\n", res));
     }
     res
-}
-
-pub fn piece_value(piece_type: PieceType, phase: f64) -> i16 {
-    piece_type.to_piece_score().interpolate(phase)
 }


### PR DESCRIPTION
Increase see pruning depth, decrease see pruning threshold, change see piece values.

Also refactored some code and prepared quiet move see pruning.

Fail lows will now never be used as best moves, and if the current best move fails low on an thread, more time will be used.