### PR TITLE
Parallelize hash initialization

### DIFF
--- a/src/uci/uci_parser.rs
+++ b/src/uci/uci_parser.rs
@@ -45,7 +45,7 @@ pub fn parse_loop() {
 
             "ucinewgame" | "newgame" => {
                 newgame(&mut us);
-                itcs.cache().clear();
+                itcs.cache().clear_threaded(itcs.uci_options().threads);
                 itcs.saved_time.store(0, Ordering::Relaxed);
             }
             "isready" => isready(&itcs, true),
@@ -297,7 +297,7 @@ pub fn setoption(cmd: &[&str], itcs: &Arc<InterThreadCommunicationSystem>) {
                 return;
             }
             "clearhash" => {
-                itcs.cache().clear();
+                itcs.cache().clear_threaded(itcs.uci_options().threads);
                 println!("info String Succesfully cleared hash!");
                 return;
             }

--- a/src/uci/uci_parser.rs
+++ b/src/uci/uci_parser.rs
@@ -291,7 +291,8 @@ pub fn setoption(cmd: &[&str], itcs: &Arc<InterThreadCommunicationSystem>) {
                     .parse::<usize>()
                     .expect("Invalid Hash value!");
                 itcs.uci_options().hash_size = num;
-                *itcs.cache() = Cache::with_size(num);
+                let num_threads = itcs.uci_options().threads;
+                *itcs.cache() = Cache::with_size_threaded(num, num_threads);
                 println!("info String Succesfully set Hash to {}", num);
                 return;
             }


### PR DESCRIPTION
Now uses the number of threads configured through UCI in most cases to accelerate initialization of Cache. Considerable speedup is achieved. No problems were found when testing with up to 24 logical threads (12 physical cores) and 16gb of RAM.