### PR TITLE
Stop grading and sorting quiet moves from the movelist, if quiets can…

### DIFF
--- a/core-sdk/src/search/alphabeta.rs
+++ b/core-sdk/src/search/alphabeta.rs
@@ -160,6 +160,7 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
     let mut current_max_score = STANDARD_SCORE;
     let mut index: usize = 0;
     let mut quiets_tried: usize = 0;
+    let mut search_quiets = true;
     let mut move_orderer = MoveOrderer {
         stage: 0,
         stages: &NORMAL_STAGES,
@@ -167,7 +168,7 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
         has_legal_move: false,
     };
     loop {
-        let mv = move_orderer.next(thread, &p, pv_table_move, tt_move);
+        let mv = move_orderer.next(thread, &p, pv_table_move, tt_move, search_quiets);
         if mv.is_none() {
             break;
         }
@@ -203,6 +204,7 @@ pub fn principal_variation_search(mut p: CombinedSearchParameters, thread: &mut 
                     thread.search_statistics.add_futil_pruning();
                 }
                 index += 1;
+                search_quiets = false;
                 continue;
             }
             //Step 14.6. History Pruning. Skip quiet moves in low depths if they are below threshold

--- a/core-sdk/src/search/quiescence.rs
+++ b/core-sdk/src/search/quiescence.rs
@@ -125,7 +125,7 @@ pub fn q_search(mut p: CombinedSearchParameters, thread: &mut Thread) -> i16 {
     };
 
     loop {
-        let mv = move_orderer.next(thread, &p, None, tt_move);
+        let mv = move_orderer.next(thread, &p, None, tt_move, false);
         if mv.is_none() {
             break;
         }


### PR DESCRIPTION
… no longer be searched

The patch is incoherent to !gives_check. Those moves will be skipped regardless.
ELO   | 10.86 +- 6.77 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5888 W: 1809 L: 1625 D: 2454
http://chess.grantnet.us/test/5670/

ELO   | 12.92 +- 7.18 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4304 W: 1110 L: 950 D: 2244
http://chess.grantnet.us/test/5674/
BENCH=15026687
