### PR TITLE
Change the nmp condition to correctly use available tt information

### DIFF
--- a/core-sdk/src/search/alphabeta.rs
+++ b/core-sdk/src/search/alphabeta.rs
@@ -487,10 +487,10 @@ pub fn null_move_pruning(
 ) -> SearchInstruction {
     if p.depth_left >= NULL_MOVE_PRUNING_DEPTH
         && p.game_state.has_non_pawns(p.game_state.get_color_to_move())
-        && static_evaluation.expect("null move static") * p.color >= p.beta
-        && (tt_entry.is_none()
-            || tt_entry.unwrap().is_upper_bound()
-            || tt_entry.unwrap().score >= p.beta)
+        && (static_evaluation.expect("null move static") * p.color >= p.beta
+            || (tt_entry.is_some()
+                && !tt_entry.unwrap().is_upper_bound()
+                && tt_entry.unwrap().score >= p.beta))
     {
         let nextgs = make_nullmove(p.game_state);
         let rat = -principal_variation_search(

--- a/core-sdk/src/search/alphabeta.rs
+++ b/core-sdk/src/search/alphabeta.rs
@@ -489,7 +489,7 @@ pub fn null_move_pruning(
         && p.game_state.has_non_pawns(p.game_state.get_color_to_move())
         && static_evaluation.expect("null move static") * p.color >= p.beta
         && (tt_entry.is_none()
-            || !tt_entry.unwrap().is_lower_bound()
+            || tt_entry.unwrap().is_upper_bound()
             || tt_entry.unwrap().score >= p.beta)
     {
         let nextgs = make_nullmove(p.game_state);

--- a/core-sdk/src/search/alphabeta.rs
+++ b/core-sdk/src/search/alphabeta.rs
@@ -485,12 +485,17 @@ pub fn null_move_pruning(
     static_evaluation: Option<i16>,
     tt_entry: &Option<CacheEntry>,
 ) -> SearchInstruction {
+    let tt_do_nmp = tt_entry.is_some()
+        && !tt_entry.unwrap().is_upper_bound()
+        && tt_entry.unwrap().score >= p.beta;
+    let tt_dont_nmp = tt_entry.is_some()
+        && !tt_entry.unwrap().is_lower_bound()
+        && tt_entry.unwrap().score < p.beta;
+    let static_do_nmp = static_evaluation.unwrap() * p.color >= p.beta;
     if p.depth_left >= NULL_MOVE_PRUNING_DEPTH
         && p.game_state.has_non_pawns(p.game_state.get_color_to_move())
-        && (static_evaluation.expect("null move static") * p.color >= p.beta
-            || (tt_entry.is_some()
-                && !tt_entry.unwrap().is_upper_bound()
-                && tt_entry.unwrap().score >= p.beta))
+        && (tt_do_nmp || static_do_nmp)
+        && !tt_dont_nmp
     {
         let nextgs = make_nullmove(p.game_state);
         let rat = -principal_variation_search(


### PR DESCRIPTION
We now correctly use information in the TT when checking if we want to try a null move. 
That is: 
-If the TT contains a lower bound or an exact bound and tt score >= beta : We try the null move
-If the TT contains an upper bound or an exact bound and tt score < beta: We don't try the null move
-In all other cases: We check if static eval > beta.
Passed regression tests at OpenBench:
ELO   | 7.08 +- 5.14 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10068 W: 2992 L: 2787 D: 4289
http://chess.grantnet.us/test/7407/

ELO   | 9.76 +- 6.10 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5876 W: 1471 L: 1306 D: 3099
http://chess.grantnet.us/test/7408/