### PR TITLE
Forget some history on fail highs from the aspiration window

### DIFF
--- a/core-sdk/src/search/searcher.rs
+++ b/core-sdk/src/search/searcher.rs
@@ -386,6 +386,15 @@ impl Thread {
                         beta = 16000;
                         alpha = -16000;
                     } else {
+                        for side in 0..2 {
+                            for i in 0..64 {
+                                for j in 0..64 {
+                                    self.bf_score[side][i][j] = (self.bf_score[side][i][j] / 2).max(1);
+                                    self.hh_score[side][i][j] /= 2;
+                                    self.history_score[side][i][j] /= 2;
+                                }
+                            }
+                        }
                         beta += delta;
                     }
                 }


### PR DESCRIPTION
When we fail high in an aspiration window, make it easier for the history to forget. 

The basic idea is this: Once we failed high, this might be due to a deep refutation of somewhere unrelated in the search tree. We now make it easier for the history to forget old values and adapt more easier to new scenarios. Initially found for a puzzle, for which FabChess struggled to find a mate. With the change, FabChess now immediately finds a mate. Room for future improvements.

Passed regression tests at OpenBench:
ELO   | 3.50 +- 2.79 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 32880 W: 9240 L: 8909 D: 14731
http://chess.grantnet.us/test/8183/

ELO   | 2.50 +- 1.88 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 57328 W: 12743 L: 12330 D: 32255
http://chess.grantnet.us/test/8189/

BENCH=8965041